### PR TITLE
Changed to use lmp_serial or lmp_mpi based on environment variables.

### DIFF
--- a/lammps_step/lammps.py
+++ b/lammps_step/lammps.py
@@ -191,7 +191,18 @@ class LAMMPS(seamm.Node):
 
         next_node = super().run(printer)
 
-        printer.important(self.header + '\n')
+        # Whether to run parallel and if so, how many mpi processes
+        np = os.getenv('SEAMM_LAMMPS_MPI_NP', default=None)
+        if not np:
+            np = os.getenv('SEAMM_MPI_NP', default=None)
+
+        printer.important(self.header)
+        if np and int(np) > 1:
+            printer.important(
+                '   LAMMPS using MPI with {} processes.\n'.format(np)
+            )
+        else:
+            printer.important('   LAMMPS using the serial version.\n')
 
         self.lammps_flowchart.root_directory = self.flowchart.root_directory
 
@@ -218,14 +229,14 @@ class LAMMPS(seamm.Node):
         for filename in files:
             with open(os.path.join(self.directory, filename), mode='w') as fd:
                 fd.write(files[filename])
-
         local = seamm.ExecLocal()
         return_files = ['summary_*.txt', 'trajectory_*.txt']
-        result = local.run(
-            cmd=['lammps_omp', '-sf', 'omp', '-in', 'molssi.dat'],  # nopep8
-            files=files,
-            return_files=return_files
-        )
+        if np and int(np) > 1:
+            cmd = ['mpirun', '-np', np, 'lmp_mpi', '-in', 'molssi.dat']
+        else:
+            cmd = ['lmp-serial', '-in', 'molssi.dat']
+
+        result = local.run(cmd=cmd, files=files, return_files=return_files)
 
         if result is None:
             logger.error('There was an error running LAMMPS')


### PR DESCRIPTION
Changed the LAMMPS run to use lmp_serial or lmp_mpi and mpirun, based
on the value of SEAMM_LAMMPS_MPI_NP or SEAMM_MPI_NP, in that order. If
the value exists and is larger than 1, then use the parallel
version. Otherwise the serial version is used.

This supports run LAMMPS installed from conda-forge along with
openmpi.