### PR TITLE
Bugfix: simple heat flux for Class2 forcefields

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2023.6.17 -- Bugfix: more centroid/stress/atom issues
+   * Avoided using centroid/stress/atom for heat flux in standard NVE, NVT, ... dynamics
+     with Class 2 forcefield.
+   * Added option to not use centroid/stress/atom for any forcefield.
 2023.6.16 -- Heat flux with PCFF
    * centroid/stress/atom does not work with Class 2 forcefields, so don't use for PCFF.
 2023.5.29 -- Self diffusion and other improvements

--- a/lammps_step/heat_flux.py
+++ b/lammps_step/heat_flux.py
@@ -541,20 +541,11 @@ variable            Jy delete
 variable            Jz delete
 unfix               summary
 unfix               J_filter
-unfix               S_b0
 unfix               S_p0
 unfix               PE0
-unfix               S_b_ave
 unfix               S_p_ave
 unfix               PE_ave
 unfix               dynamics
-uncompute           flux_b
-uncompute           flux_p
-uncompute           S_b
-uncompute           S_p
-uncompute           PE
-uncompute           KE
-
 """
         ]
         for compute in computes:
@@ -567,6 +558,16 @@ uncompute           KE
             post_lines.append(f"uncompute           {n}")
         for n in range(1, ndumps + 1):
             post_lines.append(f"undump              {n}")
+        if P["heat flux"] != "never":
+            if "cff" not in ffname:
+                post_lines.append("uncompute           flux_b")
+                post_lines.append("uncompute           S_b")
+                post_lines.append("unfix               S_b0")
+                post_lines.append("unfix               S_b_ave")
+            post_lines.append("uncompute           flux_p")
+            post_lines.append("uncompute           S_p")
+            post_lines.append("uncompute           PE")
+            post_lines.append("uncompute           KE")
 
         if "cff" in ffname:
             return {

--- a/lammps_step/lammps.py
+++ b/lammps_step/lammps.py
@@ -920,7 +920,7 @@ class LAMMPS(seamm.Node):
             )
             new_input_data.append("")
             new_input_data.append("")
-            new_input_data.append("info               computes fixes dumps log out")
+            new_input_data.append("info               computes fixes dumps out log")
 
         files["input"]["data"] += new_input_data
 
@@ -936,7 +936,7 @@ class LAMMPS(seamm.Node):
                 "modify flush yes sort id"
             )
             postscript.append("")
-            postscript.append("info               computes fixes dumps log out")
+            postscript.append("info               computes fixes dumps out log")
             files["postscript"] = {
                 "data": "\n".join(postscript),
                 "filename": "lammps_post.dat",

--- a/lammps_step/nve_parameters.py
+++ b/lammps_step/nve_parameters.py
@@ -158,6 +158,15 @@ class NVE_Parameters(lammps_step.EnergyParameters):
                 "heat-flux step instead of using this."
             ),
         },
+        "use centroid stress": {
+            "default": "yes",
+            "kind": "boolean",
+            "default_units": None,
+            "enumeration": ("yes", "no"),
+            "format_string": "",
+            "description": "Use centroid/stress/atom:",
+            "help_text": "Whether to use centroid/stress/atom",
+        },
         "shear stress": {
             "default": "never",
             "kind": "float",

--- a/lammps_step/tk_heat_flux.py
+++ b/lammps_step/tk_heat_flux.py
@@ -113,7 +113,7 @@ class TkHeatFlux(lammps_step.TkNVE):
         P = self.node.parameters
 
         # Then create the widgets
-        for key in ("time", "timestep", "heat flux", "sampling"):
+        for key in ("time", "timestep", "heat flux", "use centroid stress", "sampling"):
             self[key] = P[key].widget(frame)
 
         # and lay them out
@@ -155,7 +155,7 @@ class TkHeatFlux(lammps_step.TkNVE):
         # if e.g. rows are skipped to control such as "method" here
         row = 0
         widgets = []
-        for key in ("time", "timestep", "heat flux", "sampling"):
+        for key in ("time", "timestep", "heat flux", "use centroid stress", "sampling"):
             self[key].grid(row=row, column=0, sticky=tk.EW)
             widgets.append(self[key])
             row += 1

--- a/lammps_step/tk_nve.py
+++ b/lammps_step/tk_nve.py
@@ -62,7 +62,7 @@ class TkNVE(lammps_step.TkEnergy):
         row = 0
         widgets = []
         for key in lammps_step.NVE_Parameters.trajectories:
-            if title == "Heat Flux" and key == "heat flux":
+            if title == "Heat Flux" and (key == "heat flux" or "centroid" in key):
                 continue
             self[key] = P[key].widget(tframe)
             self[key].grid(row=row, column=0)


### PR DESCRIPTION
   * Avoided using centroid/stress/atom for heat flux in standard NVE, NVT, ... dynamics
     with Class 2 forcefield.
   * Added option to not use centroid/stress/atom for any forcefield.
