### PR TITLE
Switched to new installation scheme

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -13,3 +13,14 @@ jobs:
     with:
       src : lammps_step
     secrets: inherit
+
+  docker:
+    name: Docker
+    needs: release
+    uses: molssi-seamm/devops/.github/workflows/Docker.yaml@main
+    with:
+      image : molssi-seamm/seamm-lammps
+      description: A LAMMPS executable packaged for use with SEAMM or standalone
+      # Can limit platforms, e.g., linux/amd64, linux/arm64
+      platforms: linux/amd64
+    secrets: inherit

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 =======
 History
 =======
-2024.3.20 -- Switched to new installation scheme
+2024.3.21 -- Switched to new installation scheme
    * Fully support ~/SEAMM/lammps.ini
    * Updated to new installer
    * Support for Conda and Docker installation.


### PR DESCRIPTION
* Fully support ~/SEAMM/lammps.ini
* Updated to new installer
* Support for Conda and Docker installation.