### PR TITLE
Bugfix: error in formatting forcefield parameters

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2025.5.27 -- Bugfix: error in formatting forcefield parameters
+   * The cleanup of the format of 'structure.dat' accidentally converted some floating
+     point numbers into integers, with loss of precision. This is now fixed.
+
 2025.5.26 -- Added more metadata to the structure.dat file.
    * Added the original parameters, when available, plus the version of each parameter
      to the 'structure.dat' file input to LAMMPS to aid in understanding which

--- a/lammps_step/lammps.py
+++ b/lammps_step/lammps.py
@@ -156,12 +156,22 @@ def pline(
     line = f"{i:6d} {function}"
     for key in keys:
         value = values[key]
-        try:
-            value = int(values[key])
+        if isinstance(value, float):
+            line += f" {value:{fmt}}"
+        elif isinstance(value, int):
             fmt2 = fmt.split(".")[0] + "d"
             line += f" {value:{fmt2}}"
-        except ValueError:
-            line += f" {float(values[key]):{fmt}}"
+        elif isinstance(value, str):
+            if "." in value:
+                line += f" {float(value):{fmt}}"
+            else:
+                fmt2 = fmt.split(".")[0] + "s"
+                line += f" {value:{fmt2}}"
+        else:
+            raise ValueError(
+                f"Cannot handle forcefield parameter of type {type(value).__name__}:"
+                f" {value}"
+            )
 
     line += " #"
 


### PR DESCRIPTION
* The cleanup of the format of 'structure.dat' accidentally converted some floating point numbers into integers, with loss of precision. This is now fixed.