### PR TITLE
Bugfix: ReaxFF memory allocation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+2025.6.25 -- Bugfix: ReaxFF memory allocation
+   * Apparently the memory handling for reafxx in LAMMPS is kludgy, and there is an
+     empirical fudge-factor that helps solve errors with e.g. numbers of bonds. This
+     version increases the factor to 1.6 until we get more experience.
+
 2025.6.23 -- Bugfix: handling of GPUs and KOKKOS arguments
    * Fixed issue detecting GPUs caused by differences in SLURM enviroment variables
    * Fixed inconsistencies of dash vs underscore in configuration arguments cmd-args and

--- a/lammps_step/initialization.py
+++ b/lammps_step/initialization.py
@@ -590,9 +590,14 @@ class Initialization(seamm.Node):
                 charge_method = ff.charge_method
 
             if charge_method == "none":
-                lines.append("pair_style          reaxff NULL checkqeq no enobonds yes")
+                lines.append(
+                    "pair_style          reaxff NULL checkqeq no enobonds yes "
+                    "safezone 1.6"
+                )
             else:
-                lines.append("pair_style          reaxff NULL enobonds yes")
+                lines.append(
+                    "pair_style          reaxff NULL enobonds yes safezone 1.6"
+                )
             lines.append(
                 f"pair_coeff          * * forcefield.dat {' '.join(eex['atom types'])}"
             )


### PR DESCRIPTION
* Apparently the memory handling for reafxx in LAMMPS is kludgy, and there is an empirical fudge-factor that helps solve errors with e.g. numbers of bonds. This version increases the factor to 1.6 until we get more experience.