### PR TITLE
Bugfix: error in the stress parameters in the GUI

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2025.9.2 -- Bugfix: error in the stress parameters in the GUI
+   * There was an error in the setup of the stress parameters, which caused a
+     crash. This is now fixed.
+     
 2025.8.27 -- Added cell optimization to minimization step
    * Added the ability to optimize the cell during minimization, giving control over
      applied pressure or stress as well as fixing lattice directions.

--- a/lammps_step/minimization_parameters.py
+++ b/lammps_step/minimization_parameters.py
@@ -148,7 +148,7 @@ class MinimizationParameters(EnergyParameters):
         "Sxx": {
             "default": -1.0,
             "kind": "float",
-            "enumeration": ("fixed", "-1.0"),
+            "enumeration": ("fixed",),
             "default_units": "atm",
             "format_string": "s",
             "description": "Sxx:",
@@ -157,7 +157,7 @@ class MinimizationParameters(EnergyParameters):
         "Syy": {
             "default": -1.0,
             "kind": "float",
-            "enumeration": ("fixed", "-1.0"),
+            "enumeration": ("fixed",),
             "default_units": "atm",
             "format_string": "s",
             "description": "Syy:",
@@ -166,7 +166,7 @@ class MinimizationParameters(EnergyParameters):
         "Szz": {
             "default": -1.0,
             "kind": "float",
-            "enumeration": ("fixed", "-1.0"),
+            "enumeration": ("fixed",),
             "default_units": "atm",
             "format_string": "s",
             "description": "Szz:",
@@ -175,7 +175,7 @@ class MinimizationParameters(EnergyParameters):
         "Syz": {
             "default": "fixed",
             "kind": "float",
-            "enumeration": ("fixed", "0.0"),
+            "enumeration": ("fixed",),
             "default_units": "atm",
             "format_string": "s",
             "description": "Syz:",
@@ -184,7 +184,7 @@ class MinimizationParameters(EnergyParameters):
         "Sxz": {
             "default": "fixed",
             "kind": "float",
-            "enumeration": ("fixed", "0.0"),
+            "enumeration": ("fixed",),
             "default_units": "atm",
             "format_string": "s",
             "description": "Sxz:",
@@ -193,7 +193,7 @@ class MinimizationParameters(EnergyParameters):
         "Sxy": {
             "default": "fixed",
             "kind": "float",
-            "enumeration": ("fixed", "0.0"),
+            "enumeration": ("fixed",),
             "default_units": "atm",
             "format_string": "s",
             "description": "Sxy:",


### PR DESCRIPTION
* There was an error in the setup of the stress parameters, which caused a crash. This is now fixed.