### PR TITLE
QM-MD over MDI: driver path, single-core/thermo refinements, task|level labels

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -33,6 +33,7 @@ dependencies:
   # Pip-only installs
   - pip:
     - gputil
+    - model-chemistry-step
     - pymbar>=4.0
     - seamm-exec
     # Documentation

--- a/docs/developer_guide/campaigns/2026-06-22/NOTES_C.rst
+++ b/docs/developer_guide/campaigns/2026-06-22/NOTES_C.rst
@@ -6,8 +6,16 @@ Phase C -- LAMMPS driver: read ``_model_chemistry``, launch the MDI engine
 
 :Author: Paul Saxe (with Claude)
 :Date: 2026-06-24
-:Status: Implemented (2026-06-24) -- ``lammps.py`` + ``initialization.py`` +
-         unit tests done (14 pass). Manual end-to-end run still pending.
+:Status: MDI launch path verified end-to-end (2026-06-24). ``lammps.py`` +
+         ``initialization.py`` + unit tests (14 pass). A MOPAC PM6-ORG
+         minimization of a 45-atom C/O/H system ran via MDI: engine launched in
+         seamm-mopac, connected over TCP, drove LAMMPS, exited cleanly (energy
+         -266.7 -> -309.5 kcal/mol). Open: the CG min stopped at
+         "linesearch alpha is zero" (not converged) -- investigate QM
+         energy/force consistency, separate from the launch path. NOTE: reusing
+         the lammps.ini ``code`` key requires it to be a plain LAMMPS launcher
+         (``mpirun -n {NTASKS} lmp``), NOT a MACE-style MDI/MPMD line -- that is
+         what ``gpu-code`` is for.
 :Campaign: LAMMPS + MOPAC/xTB QM-MD via MDI
 
 .. contents:: Contents
@@ -276,6 +284,27 @@ Decisions (resolved 2026-06-24)
    into ``get_mdi_engine_command`` (what ``mopac.py`` itself does). Note: LAMMPS's
    ``fix mdi/qm`` does **not** send ``>TOTCHARGE`` / ``>ELEC_MULT``, so these are
    fixed for the whole run at launch -- acceptable for a single-species MD box.
+
+
+Post-verification refinements (2026-06-24)
+==========================================
+
+Found while running the first NVT and minimization jobs:
+
+#. **Single core / single thread.** The QM engine does essentially all the work
+   and is the bottleneck, so LAMMPS is forced to ``np = 1`` on the MDI/QM path
+   (``lammps.py``), and ``OMP_NUM_THREADS`` / ``MKL_NUM_THREADS`` are set to 1 in
+   the run environment. Because that environment wraps the whole launch script,
+   both the MOPAC engine (which was otherwise grabbing all cores via OpenMP) and
+   the LAMMPS driver stay single-threaded.
+
+#. **Thermo columns.** As for MLFFs (the ``PyTorch`` form), the per-term energy
+   columns ``ebond eangle edihed eimp evdwl etail ecoul elong`` are dropped from
+   the ``thermo_style`` on the MDI/QM path -- they are always zero when the
+   energy comes from an external engine. The guard
+   ``if form not in ("PyTorch", "MDI/QM")`` now covers ``nve.py``, ``nvt.py``,
+   ``npt.py`` and ``minimization.py`` (the last previously emitted the zero
+   columns even for MLFFs).
 
 
 Tests

--- a/docs/developer_guide/campaigns/2026-06-22/NOTES_C.rst
+++ b/docs/developer_guide/campaigns/2026-06-22/NOTES_C.rst
@@ -1,0 +1,310 @@
+.. _notes-mdi-lammps-phase-c:
+
+==========================================================================
+Phase C -- LAMMPS driver: read ``_model_chemistry``, launch the MDI engine
+==========================================================================
+
+:Author: Paul Saxe (with Claude)
+:Date: 2026-06-24
+:Status: Implemented (2026-06-24) -- ``lammps.py`` + ``initialization.py`` +
+         unit tests done (14 pass). Manual end-to-end run still pending.
+:Campaign: LAMMPS + MOPAC/xTB QM-MD via MDI
+
+.. contents:: Contents
+   :depth: 2
+   :local:
+
+
+Phase numbering
+===============
+
+This campaign grew a step. ``NOTES_A`` (written 2026-06-23, in
+``molssi-seamm.github.io``) calls the LAMMPS driver work "Phase B", because at
+that point the only two halves were *MOPAC engine* and *LAMMPS driver*. We then
+inserted the **Model Chemistry step** as a first-class producer (``NOTES_B``, in
+``model_chemistry_step``), which took the name "Phase B". The LAMMPS driver is
+therefore **Phase C**. Where ``NOTES_A`` says "Phase B (lammps_step)", read
+"Phase C". The contract did not change, only the label.
+
+
+Scope
+=====
+
+Phase C delivers the **LAMMPS side** of QM-MD over MDI: ``lammps_step`` reads the
+``_model_chemistry`` workspace variable published by the Model Chemistry step
+(Phase B), validates it can be driven via MDI, asks the owning program step for
+its engine launch command (Phase A's ``get_mdi_engine_command``), allocates a
+TCP rendezvous, composes a launch script that runs engine + LAMMPS together, and
+runs it -- closing the thin line "select MOPAC PM6-ORG, then drive LAMMPS MD with
+it via MDI".
+
+In scope:
+
+* Detect the QM/MDI path: ``_model_chemistry`` present (mirrors how the existing
+  code branches on ``_forcefield`` being ``"OpenKIM"`` / ``"PyTorch"``).
+* Validate ``options["mdi_capable"]`` (and ``options["periodic_mdi"]`` for a
+  periodic configuration) with a helpful error if the selection cannot be driven.
+* Resolve the owning step via the Stevedore handle
+  (``self.flowchart.plugin_manager.manager[mc["step"]].obj``) and call
+  ``get_mdi_engine_command(...)`` on it.
+* Allocate a free TCP port (``NOTES_A`` ``_free_tcp_port`` helper) and choose the
+  hostname; pass the *same* values to engine and driver.
+* Build the LAMMPS (driver) argv for TCP transport from ``lammps.ini`` -- the
+  same ini-reading machinery already in ``LAMMPS.run()``.
+* Compose the bash launch script: engine backgrounded first (it is the
+  listener), driver second, ``wait`` last (``NOTES_A`` "Launch script shape").
+* Generate the LAMMPS input deck: ``fix ... all mdi/qm ... elements <types>``,
+  reusing the existing MACE/PyTorch path in ``initialization.py``.
+* Charge / multiplicity from the ``configuration`` object
+  (``configuration.charge`` / ``configuration.spin_multiplicity``), per SEAMM
+  convention -- never from the model-chemistry step.
+
+Deferred:
+
+* xTB (revisit once MOPAC works end to end -- it just needs its own Phase A).
+* Non-conda engine launches (local / modules / docker); Phase A's
+  ``get_mdi_engine_command`` already raises ``NotImplementedError`` for these.
+* Concurrent-job port-collision retry (``NOTES_A`` "Port allocation").
+* GPU binding for the QM engine. MOPAC is CPU-only, so the MACE ``mdi_bind.sh`` /
+  ``mdi_monitor.sh`` GPU-pinning wrappers are *not* on the MOPAC path.
+
+
+What we consume (the Phase B contract)
+======================================
+
+``self.get_variable("_model_chemistry")`` returns::
+
+    {
+        "model_chemistry": "MOPAC:SQM@PM6-ORG",   # canonical string
+        "program": "MOPAC", "type": "SQM", "method": "PM6-ORG",
+        "basis": None, "cutoff": None,
+        "step": "<stevedore plugin name>",         # resolution handle
+        "options": {                               # full get_model_chemistry_options() entry
+            "mdi_capable": True,
+            "periodic_mdi": False,
+            "mdi_method_arg": "PM6-ORG",
+            "elements": "...", "description": "...", ...
+        },
+    }
+
+Phase C reads ``mc["step"]`` to resolve the owner, ``mc["method"]`` (or
+``options["mdi_method_arg"]``) for the engine, and the two ``options`` booleans
+to gate MDI launch. It needs nothing else from the program step except the argv
+that ``get_mdi_engine_command`` returns.
+
+
+The existing MACE path, and why MOPAC is a *new* path
+=====================================================
+
+``lammps_step`` already drives an MDI engine -- MACE -- but the launch model is
+materially different from MOPAC's, so Phase C adds a parallel path rather than
+extending the MACE one.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 41 41
+
+   * - Aspect
+     - MACE (existing)
+     - MOPAC (Phase C)
+   * - Transport
+     - MDI ``-method MPI``
+     - MDI ``-method TCP -port -hostname``
+   * - Launch
+     - Single ``mpirun ... : ...`` multiple-program line, *hardwired in*
+       ``lammps.ini``
+     - bash script: engine ``&`` then driver, then ``wait``
+   * - Engine env
+     - same conda env as LAMMPS, plain ``python``
+     - **separate** conda env (``seamm-mopac``) via ``conda run``
+   * - Engine argv
+     - fixed string in ``lammps.ini``
+     - returned by the program step's ``get_mdi_engine_command()``
+   * - Engine binary
+     - ``data/mace_mdi.py``
+     - ``mopac_step/data/mopac_mdi.py``
+   * - GPU pinning
+     - ``mdi_bind.sh`` / ``mdi_monitor.sh``
+     - none (MOPAC is CPU-only)
+
+Shared, and reused as-is: the input-deck generation. Both emit
+``fix mdi_fix all mdi/qm [virial yes] elements <atom types>`` and *no*
+``pair_style`` (``initialization.py``, ``PyTorch_input``). The QM path differs
+only in *who is launched and how*, not in what LAMMPS is told to do.
+
+Why TCP, not MPI, for MOPAC: the engine lives in a different conda environment.
+You cannot put two different conda environments into one ``mpirun ... : ...``
+MPMD launch and have MDI's MPI transport rendezvous across them. TCP decouples
+the two processes -- each is launched however its own step wants (``conda run``
+for MOPAC, plain for LAMMPS) and they meet on a socket. This is exactly the split
+of responsibility ``NOTES_A`` fixed: driver owns the rendezvous (port/host),
+engine owns its own launch line.
+
+
+Proposed design
+===============
+
+Detection -- ``ff_form()`` / ``run()`` (``lammps.py``)
+------------------------------------------------------
+
+Today ``ff_form()`` branches on ``_forcefield`` being ``"OpenKIM"`` /
+``"PyTorch"`` / a forcefield object. Add a QM branch *before* touching
+``_forcefield``, because a QM-MD flowchart has a Model Chemistry step and **no**
+Forcefield step::
+
+    if self.variable_exists("_model_chemistry"):
+        return "MDI/QM"           # new form
+    ff = self.get_variable("_forcefield")
+    ...
+
+``run()`` then, for ``ff_form == "MDI/QM"``, sets ``self.model = "MDI/QM/" +
+mc["model_chemistry"]`` (so summaries/labels read sensibly) and skips the
+forcefield-assignment machinery.
+
+Engine launch -- new helper in ``lammps.py``
+---------------------------------------------
+
+A focused method, called from ``run()`` on the QM path, that returns the engine
+argv and the rendezvous it picked::
+
+    def _mdi_engine_launch(self, configuration):
+        mc = self.get_variable("_model_chemistry")
+        options = mc["options"]
+
+        periodic = configuration.periodicity != 0
+        if not options.get("mdi_capable"):
+            raise ValueError(
+                f"The model chemistry '{mc['model_chemistry']}' cannot be "
+                "driven via MDI."
+            )
+        if periodic and not options.get("periodic_mdi"):
+            raise ValueError(
+                f"The model chemistry '{mc['model_chemistry']}' is not "
+                "validated for periodic systems via MDI."
+            )
+
+        port = _free_tcp_port()                 # NOTES_A helper, host "localhost"
+        step = self.flowchart.plugin_manager.manager[mc["step"]].obj
+        engine_argv = step.get_mdi_engine_command(
+            self.flowchart.executor,
+            self.global_options,
+            method=mc["method"],
+            port=port,
+            hostname="localhost",
+            charge=configuration.charge,
+            multiplicity=configuration.spin_multiplicity,
+        )
+        return engine_argv, port
+
+Driver argv (LAMMPS, TCP DRIVER side)
+-------------------------------------
+
+Built from the existing ``lammps.ini`` ``code`` / ``cmd-args`` keys (the CPU
+path; GPU/Kokkos is irrelevant for a CPU QM engine), plus the MDI driver flag
+and the input file::
+
+    driver_argv = [config["code"], *config["cmd-args"].split(),
+                   "-mdi", f"-role DRIVER -name LAMMPS -method TCP "
+                           f"-port {port} -hostname localhost",
+                   "-in", "input.dat"]
+
+Launch script (``NOTES_A`` shape)
+---------------------------------
+
+::
+
+    #!/bin/bash
+    set -e
+    <shlex.join(engine_argv)> &
+    ENGINE_PID=$!
+    <shlex.join(driver_argv)>
+    wait $ENGINE_PID
+
+The engine is backgrounded first because it is the listener
+(``MDI_Accept_Communicator``); the driver connects and retries. We then run this
+script through ``executor.run(..., shell=True)``, the way the existing path runs
+its command. ``conda run --live-stream`` (already in the engine argv from
+Phase A) keeps the engine's stdout/stderr interleaved into the job output.
+
+Input deck -- reuse ``initialization.py``
+-----------------------------------------
+
+Route ``ff_form == "MDI/QM"`` to the same code as ``"PyTorch"`` for the ``.pt``
+branch: emit no ``pair_style`` and::
+
+    fix    mdi_fix all mdi/qm [virial yes] elements <atom types>
+
+(``virial yes`` only when periodic). The element list comes from the system, as
+it does on the MACE path. This is the one place the two MDI paths converge.
+
+
+Decisions (resolved 2026-06-24)
+===============================
+
+#. **D1 -- New ``ff_form`` value ``"MDI/QM"``, discriminated by**
+   ``_model_chemistry`` **being present.** *Resolved: yes.* The branch is checked
+   *before* ``_forcefield`` (a QM-MD flowchart has no Forcefield step, so
+   ``_forcefield`` does not exist). No GUI toggle -- variable-presence mirrors the
+   existing ``_forcefield`` / ``_OpenKIM_Potential`` precedent.
+
+#. **D2 -- TCP + bash launch script.** *Resolved: TCP + script.* The engine runs
+   in a separate conda env (``seamm-mopac``) via ``conda run``; two conda envs
+   cannot share one ``mpirun ... : ...`` MPMD launch for MDI's MPI transport, so
+   the MACE MPMD line is **not** reused. A second launch path is the accepted
+   cost; it preserves Phase A's "engine owns its own env" design.
+
+#. **D3 -- ``_mdi_engine_launch`` helper; rest inline.** *Resolved, with a small
+   amendment during implementation.* The ``_mdi_engine_launch`` method picks the
+   port and builds the engine argv. The driver-argv + script assembly were
+   pulled out of ``run()`` into a pure module-level ``_mdi_launch_script(engine_argv,
+   port, config, ce)`` (rather than left inline) **purely so the script shape and
+   the driver-line template resolution are unit-testable** -- ``run()`` now just
+   calls the two helpers. No new ``get_executor_config``-style method on
+   ``lammps_step``; the inline ini-reading already there suffices.
+
+#. **D4 -- Reuse ``code`` / ``cmd-args``.** *Resolved.* The driver argv is built
+   from the existing CPU ``lammps.ini`` keys (GPU/Kokkos keys ignored -- MOPAC is
+   CPU-only), with the MDI DRIVER flag and ``-in input.dat`` appended. No
+   dedicated ``mdi-code`` key.
+
+#. **D5 -- Simple ``_free_tcp_port``, retry deferred.** *Resolved.* Accept the
+   TOCTOU window for the one-job-per-node case; defer the bind-failure retry
+   (``NOTES_A`` open question 3) to a later pass.
+
+#. **D6 -- Charge / multiplicity from the configuration.** *Resolved.* Read
+   ``configuration.charge`` and ``configuration.spin_multiplicity`` and pass them
+   into ``get_mdi_engine_command`` (what ``mopac.py`` itself does). Note: LAMMPS's
+   ``fix mdi/qm`` does **not** send ``>TOTCHARGE`` / ``>ELEC_MULT``, so these are
+   fixed for the whole run at launch -- acceptable for a single-species MD box.
+
+
+Tests
+=====
+
+* Unit: ``_free_tcp_port`` returns a bindable integer.
+* Unit: the QM detection branch in ``ff_form`` (mock ``_model_chemistry``
+  present / absent).
+* Unit: launch-script composition -- given a stub ``_model_chemistry`` and a
+  stub program step whose ``get_mdi_engine_command`` returns a known argv, assert
+  the script backgrounds the engine, runs the driver with the matching
+  ``-port`` / ``-hostname``, and waits on the engine. No real engine, no real
+  socket.
+* Unit: MDI-capability gating raises the right ``ValueError`` for a
+  non-``mdi_capable`` selection and for periodic-without-``periodic_mdi``.
+* (Manual / integration, out of CI) the end-to-end thin line: MOPAC PM6-ORG
+  driving a few MD steps on a small molecule.
+
+
+References
+==========
+
+* Phase A engine contract: ``molssi-seamm.github.io`` ..
+  ``campaigns/2026-06-22/NOTES_A.rst`` (``get_mdi_engine_command``,
+  ``get_executor_config``, ``_free_tcp_port``, launch-script shape, port race).
+* Phase B producer + contract: ``model_chemistry_step`` ..
+  ``campaigns/2026-06-22/NOTES_B.rst`` and ``model_chemistry_step/grammar.py``.
+* Existing MDI path (reused input deck): ``lammps_step/lammps_step/lammps.py``
+  (``ff_form`` ~629, model selection ~649, ini/command building ~1001-1149) and
+  ``initialization.py`` (``PyTorch_input``, ``fix mdi/qm`` ~807).
+* LAMMPS ``fix mdi/qm``: https://docs.lammps.org/fix_mdi_qm.html
+* MDI Library (TCP transport, roles): https://molssi-mdi.github.io/MDI_Library/

--- a/docs/developer_guide/campaigns/2026-06-22/NOTES_C_runbook.rst
+++ b/docs/developer_guide/campaigns/2026-06-22/NOTES_C_runbook.rst
@@ -1,0 +1,215 @@
+.. _notes-mdi-lammps-phase-c-runbook:
+
+==================================================================
+Phase C runbook -- manual end-to-end verification of QM-MD via MDI
+==================================================================
+
+:Author: Paul Saxe (with Claude)
+:Date: 2026-06-24
+:Status: Procedure -- not yet executed
+:Campaign: LAMMPS + MOPAC/xTB QM-MD via MDI
+
+.. contents:: Contents
+   :depth: 2
+   :local:
+
+
+Purpose
+=======
+
+The Phase C unit tests (``tests/test_mdi_qm.py``) cover detection, MDI-capability
+gating, engine resolution, and launch-script composition with stubs -- but
+nothing in CI actually starts a MOPAC engine or runs LAMMPS. This runbook is the
+manual "thin line" check: **select MOPAC PM6-ORG, then drive a few LAMMPS MD
+steps with it via MDI**, end to end, and confirm it works. Run it once after the
+Phase C code lands, and again whenever the engine contract or launch path
+changes.
+
+
+Prerequisites
+=============
+
+Three conda environments, the standard SEAMM split (the launch script relies on
+exactly this -- the driver runs in seamm-lammps, the engine in seamm-mopac):
+
+* **seamm** -- the environment SEAMM itself runs in. Must have, importable:
+  ``lammps_step`` (with the Phase C code), ``model_chemistry_step``,
+  ``mopac_step`` (with the Phase A engine contract). Install editable if testing
+  local changes::
+
+      conda activate seamm
+      pip install -e /Users/psaxe/Work/SEAMM/lammps_step
+      pip install -e /Users/psaxe/Work/SEAMM/model_chemistry_step
+      pip install -e /Users/psaxe/Work/SEAMM/mopac_step
+
+* **seamm-lammps** -- the LAMMPS binary, **built with the MDI package** so
+  ``fix mdi/qm`` exists. Verify::
+
+      conda run -n seamm-lammps lmp -h | grep -i mdi      # expect mdi/qm listed
+
+* **seamm-mopac** -- MOPAC plus the engine's imports (``mopactools``,
+  ``pymdi``/``mdi``, ``numpy``, ``seamm_util``). The engine script
+  ``mopac_mdi.py`` is shipped in ``mopac_step/data/`` and run from there; it must
+  import *only* packages present in this environment (NOTES_A, Option C). Verify::
+
+      conda run -n seamm-mopac python -c "import mopactools, mdi, numpy, seamm_util"
+
+The ini files must select the conda installs:
+
+* ``~/SEAMM/mopac.ini`` -- the active executor section has
+  ``installation = conda`` and ``conda-environment = seamm-mopac``. (Non-conda
+  raises ``NotImplementedError`` by design -- NOTES_A.)
+* ``~/SEAMM/lammps.ini`` -- the active executor section has a ``code`` key (e.g.
+  ``mpirun -np {NTASKS} lmp``) and ``installation = conda`` /
+  ``conda-environment = seamm-lammps``.
+
+
+Pre-flight smoke checks (cheap, isolate failures early)
+=======================================================
+
+Do these before a full job; each isolates one layer.
+
+#. **Discovery** -- the program-step sweep offers MOPAC PM6-ORG. Check the
+   producing classmethod directly (no flowchart needed)::
+
+       conda run -n seamm python -c "
+       from mopac_step.mopac_step import MOPACStep
+       opts = MOPACStep.get_model_chemistry_options(mdi_only=True)
+       print(sorted(opts))
+       assert any(o.get('model_chemistry') == 'MOPAC:SQM@PM6-ORG'
+                  and o['mdi_capable'] for o in opts.values())
+       print('PM6-ORG is MDI-capable: OK')
+       "
+
+   Or, in the SEAMM GUI, open a Model Chemistry step and confirm
+   ``MOPAC:SQM@PM6-ORG`` appears in the combobox.
+
+#. **Engine stands alone** -- the MOPAC MDI engine accepts a TCP connection
+   without LAMMPS. In one shell start the engine::
+
+       conda run -n seamm-mopac python \
+           /Users/psaxe/Work/SEAMM/mopac_step/mopac_step/data/mopac_mdi.py \
+           -mdi "-role ENGINE -name MOPAC -method TCP -port 8021 -hostname localhost" \
+           --method PM6-ORG --charge 0 --multiplicity 1
+
+   It should bind the port and block in ``MDI_Accept_Communicator`` (log line
+   "MDI connection established" appears only once a driver connects). Ctrl-C to
+   stop. A bind error here means the port is taken -- pick another.
+
+#. **MDI TCP semantics** -- confirm MDI's TCP transport needs the *same explicit*
+   ``-port`` on both sides and has no port-0/auto option (NOTES_A "Unverified"
+   warning). If a port-file handshake exists, prefer it and revisit ``NOTES_C``
+   (it would remove the D5 race).
+
+
+The thin-line run
+=================
+
+#. **Build the flowchart** (SEAMM GUI or a ``.flow`` file):
+
+   #. **Model Chemistry** step -- select ``MOPAC:SQM@PM6-ORG``. (Leave
+      "periodic" off for the first run.)
+   #. **LAMMPS** step -- inside it: an **Initialization** sub-step, then a short
+      **molecular dynamics** sub-step (NVE or NVT, ~50-100 steps, ~0.5 fs).
+
+#. **Pick a tiny non-periodic system** -- e.g. a single water molecule or a
+   small organic molecule, charge 0, multiplicity 1. Set charge/multiplicity on
+   the configuration (these flow to the engine via
+   ``configuration.charge`` / ``configuration.spin_multiplicity`` -- D6).
+
+#. **Run the job.**
+
+
+What to check
+=============
+
+In the LAMMPS step's working directory:
+
+* ``mdi_launch.sh`` exists and looks like::
+
+      #!/bin/bash
+      set -e
+      '<conda>' run --live-stream -n seamm-mopac python .../mopac_mdi.py -mdi '-role ENGINE ... -port NNNNN -hostname localhost' --method PM6-ORG ... &
+      ENGINE_PID=$!
+      mpirun -np 1 lmp -mdi "-role DRIVER -name LAMMPS -method TCP -port NNNNN -hostname localhost" -in input.dat
+      wait $ENGINE_PID
+
+  -- the **same port NNNNN** on both lines (the rendezvous), engine backgrounded
+  first.
+
+* ``input.dat`` contains ``fix mdi_fix all mdi/qm elements ...`` and **no**
+  ``pair_style`` (the QM engine provides the forces).
+
+* ``stdout.txt`` / ``stderr.txt`` -- the engine's "MDI connection established"
+  appears, then LAMMPS runs the requested number of steps with finite energies
+  and forces. No "address already in use".
+
+* ``log.lammps`` -- the MD loop completed; temperature/energy are physically
+  sane (not NaN, not exploding on step 1).
+
+Success = the MD trajectory advances the requested steps with forces that
+clearly came from PM6-ORG (e.g. reasonable bond lengths / energies), and the
+engine exits cleanly when LAMMPS sends ``EXIT``.
+
+
+Troubleshooting
+===============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Symptom
+     - Likely cause
+     - Fix / where to look
+   * - ``ValueError: ... cannot be driven via MDI``
+     - Method not in ``_MDI_CAPABLE_METHODS`` (gating in ``_mdi_engine_launch``)
+     - Pick an MDI-capable method (PM7, PM6-D3H4, PM6-ORG, PM6, AM1, RM1).
+   * - ``ValueError: ... not validated for periodic``
+     - Periodic system + method not in ``_MDI_PERIODIC_VALIDATED``
+     - Use a non-periodic system, or a method in ``_MDI_PERIODIC_VALIDATED``
+       (mopac_step).
+   * - ``NotImplementedError`` from the engine command
+     - ``mopac.ini`` installation != conda
+     - Set the executor section to ``installation = conda`` (non-conda is a
+       Phase B+ item, NOTES_A).
+   * - Engine dies "address already in use"
+     - Port race (TOCTOU, D5)
+     - Re-run. Persisting under concurrency -> add the bind-failure retry
+       (NOTES_A open Q3).
+   * - Hangs forever at connection
+     - ``-port`` / ``-hostname`` mismatch, or MDI TCP port semantics (NOTES_A)
+     - Confirm both lines in ``mdi_launch.sh`` share the port; verify MDI TCP
+       needs matching ports.
+   * - ``fix mdi/qm`` unknown in LAMMPS
+     - LAMMPS built without the MDI package
+     - Rebuild seamm-lammps with ``-DPKG_MDI=on``.
+   * - Engine ImportError under conda run
+     - Engine imported a seamm / mopac_step module not in seamm-mopac
+     - Keep ``mopac_mdi.py`` importing only seamm-mopac packages (NOTES_A,
+       Option C).
+   * - Ghost-atom / comm cutoff warnings from LAMMPS
+     - ``comm_modify`` intentionally dropped on the QM path (NOTES_C)
+     - Revisit ``MDI_QM_input`` -- the MACE path set ``comm_modify cutoff 2.0``;
+       add if needed.
+   * - Wrong charge / spin in the QM energies
+     - configuration charge / multiplicity unset
+     - Set them on the system; they pass through D6.
+
+
+After a successful run
+======================
+
+* Flip ``NOTES_C`` status to "Verified end-to-end (<date>)".
+* Then the deferred items become live work: periodic systems, xTB (its own Phase
+  A), non-conda launches, and the concurrent-job port retry.
+
+
+References
+==========
+
+* Phase C design + decisions: ``NOTES_C.rst`` (this directory).
+* Phase A engine contract / port race / MDI TCP warning:
+  ``molssi-seamm.github.io`` .. ``campaigns/2026-06-22/NOTES_A.rst``.
+* LAMMPS ``fix mdi/qm``: https://docs.lammps.org/fix_mdi_qm.html
+* MDI Library (TCP transport): https://molssi-mdi.github.io/MDI_Library/

--- a/docs/developer_guide/campaigns/2026-06-22/index.rst
+++ b/docs/developer_guide/campaigns/2026-06-22/index.rst
@@ -1,0 +1,14 @@
+LAMMPS + MOPAC/xTB QM-MD via MDI
+================================
+
+Driver-side (``lammps_step``) notes for the campaign that lets LAMMPS run MD
+with forces from a semiempirical QM engine (MOPAC, later xTB) over the MDI
+protocol.
+
+Contents:
+
+.. toctree::
+   :glob:
+   :maxdepth: 2
+
+   NOTES_*

--- a/docs/developer_guide/campaigns/index.rst
+++ b/docs/developer_guide/campaigns/index.rst
@@ -1,0 +1,14 @@
+Campaigns
+=========
+
+Design notes and working journals for multi-step development campaigns. Each
+dated subdirectory holds the notes for one campaign; ``NOTES_*`` files capture
+the design as it unfolds.
+
+Contents:
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+
+   */index

--- a/docs/developer_guide/index.rst
+++ b/docs/developer_guide/index.rst
@@ -9,3 +9,4 @@ Contents:
    installation
    usage
    contributing
+   campaigns/index

--- a/lammps_step/energy.py
+++ b/lammps_step/energy.py
@@ -116,10 +116,20 @@ class Energy(seamm.Node):
 
         self.description = "A single point energy calculation"
 
+    # The model-chemistry task this operation performs (SP | OPT | MD); used to
+    # compose the provenance label. Overridden in the dynamics / minimization
+    # subclasses. See model_chemistry_naming.rst.
+    task = "SP"
+
     @property
     def model(self):
-        """The name of the forcefield."""
-        return self.parent.model
+        """The full ``driver:task|level`` provenance label for this operation.
+
+        Composed from the parent's model chemistry and this step's ``task`` --
+        e.g. ``LAMMPS:MD|MOPAC:SQM@PM6-ORG`` -- so results are labeled (and made
+        comparable) by what was actually done.
+        """
+        return self.parent.model_chemistry(self.task)
 
     @model.setter
     def model(self, value):

--- a/lammps_step/heat_flux_parameters.py
+++ b/lammps_step/heat_flux_parameters.py
@@ -37,7 +37,7 @@ class HeatFluxParameters(NVE_Parameters):
     parameters : {str: {str: str}}
         A dictionary containing the parameters for the current step.
         Each key of the dictionary is a dictionary that contains the
-        the following keys:
+        the following keys
 
     parameters["default"] :
         The default value of the parameter, used to reset it.
@@ -51,7 +51,7 @@ class HeatFluxParameters(NVE_Parameters):
         is a convergence criterion for an optimizer, custom values like "normal",
         "precise", etc, might be adequate. In addition, any parameter can be set to a
         variable of expression, indicated by having "$" or "=" as the first character
-         in the field. For example, $OPTIMIZER_CONV.
+        in the field. For example, $OPTIMIZER_CONV.
 
     parameters["default_units"] : str
         The default units, used for resetting the value.

--- a/lammps_step/initialization.py
+++ b/lammps_step/initialization.py
@@ -175,6 +175,8 @@ class Initialization(seamm.Node):
             return self.OpenKIM_input()
         if ff_form == "PyTorch":
             return self.PyTorch_input()
+        if ff_form == "MDI/QM":
+            return self.MDI_QM_input()
 
         # Valence forcefield...
         ff = self.get_variable("_forcefield")
@@ -817,6 +819,77 @@ class Initialization(seamm.Node):
             lines.append("pair_style          mace no_domain_decomposition")
             lines.append(
                 f"pair_coeff          * * {model} {' '.join(eex['atom types'])}"
+            )
+
+        # Set up standard variables
+        for variable in thermo_variables:
+            lines.append("variable            {var} equal {var}".format(var=variable))
+
+        if periodicity == 3:
+            # For convenience, stress
+            for d in ("xx", "yy", "zz", "xy", "xz", "yz"):
+                lines.append(f"variable            s{d} equal -p{d}")
+
+        self.description.append(__(string, indent=self.indent + 4 * " "))
+
+        return (lines, eex)
+
+    def MDI_QM_input(self):
+        """Initialization input for QM-MD driven over MDI (e.g. MOPAC).
+
+        The QM engine computes the energy and forces for the whole system, so
+        LAMMPS needs no ``pair_style`` -- only ``fix mdi/qm``, which ships the
+        atoms to the engine and receives the forces back, exactly as the MACE
+        ``.mace.pt`` path does. The engine itself is launched by ``lammps.py``;
+        here we only write the input deck. See
+        campaigns/2026-06-22/NOTES_C.rst.
+        """
+        # Get the configuration
+        system_db = self.get_variable("_system_db")
+        configuration = system_db.system.configuration
+
+        # Get the (simple) energy expression for these systems. It is generic
+        # (elements / coordinates / masses), so the PyTorch helper is reused.
+        eex = self.PyTorch_energy_expression()
+
+        lammps_step.set_lammps_unit_system("metal")
+
+        lines = []
+        lines.append("")
+        lines.append(f"# {self.header}")
+        lines.append("")
+        lines.append("units               metal")
+        lines.append("atom_style          atomic")
+        lines.append("atom_modify         map yes")
+        lines.append("newton              on")
+        lines.append("")
+
+        periodicity = configuration.periodicity
+        if periodicity == 0:
+            lines.append("boundary            s s s")
+            string = "Setup for a molecular (non-periodic) system."
+        elif periodicity == 3:
+            lines.append("boundary            p p p")
+            string = "Setup for a periodic (crystalline or fluid) system."
+        else:
+            raise RuntimeError(
+                "The LAMMPS step can only handle 0-"
+                " or 3-D periodicity at the moment!"
+            )
+        lines.append("")
+        lines.append("fix                 prop all property/atom mol")
+        lines.append("read_data           structure.dat fix prop NULL Molecules")
+        lines.append("")
+        lines.append("#    Drive the QM engine over MDI (no pair style needed)")
+        if periodicity == 0:
+            lines.append(
+                "fix                 mdi_fix all mdi/qm elements "
+                f"{' '.join(eex['atom types'])}"
+            )
+        else:
+            lines.append(
+                "fix                 mdi_fix all mdi/qm virial yes elements "
+                f"{' '.join(eex['atom types'])}"
             )
 
         # Set up standard variables

--- a/lammps_step/lammps.py
+++ b/lammps_step/lammps.py
@@ -19,6 +19,7 @@ import pprint
 import re
 import shlex
 import shutil
+import socket
 import string
 import sys
 import textwrap
@@ -65,6 +66,79 @@ def _get_script_version(text):
         if m:
             return m.group(1), m.group(2)
     return None, None
+
+
+def _free_tcp_port(hostname="localhost"):
+    """Ask the OS for a free TCP port for the MDI rendezvous.
+
+    Bind a throwaway socket to port 0, read back the port the OS assigned,
+    release it, and return that integer for both the engine and the LAMMPS
+    driver to use. There is an unavoidable race between releasing the socket
+    and the engine re-binding it (classic TOCTOU); acceptable for the typical
+    one-job-per-node case. See campaigns/2026-06-22/NOTES_C.rst (D5).
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind((hostname, 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
+def _mdi_launch_script(engine_argv, port, config, ce, hostname="localhost"):
+    """Compose the bash launch script for QM-MD over MDI.
+
+    The QM engine is the listener (it binds the port and blocks in
+    MDI_Accept_Communicator), so it is backgrounded first; the LAMMPS driver
+    runs second and connects; then we wait on the engine. ``executor.run``
+    wraps this whole script in the seamm-lammps conda env, while the engine
+    line carries its own ``conda run -n seamm-mopac`` so each code stays in its
+    own environment. See campaigns/2026-06-22/NOTES_C.rst.
+
+    Parameters
+    ----------
+    engine_argv : list of str
+        The fully resolved engine launch argv (from the program step's
+        get_mdi_engine_command); rendered with shlex.join.
+    port : int
+        The TCP port both sides use.
+    config : dict
+        The lammps.ini section. The driver command comes from its "code" /
+        "cmd-args" keys (D4).
+    ce : dict
+        The computational environment, for resolving ini templates such as
+        {NTASKS}.
+    hostname : str
+        The rendezvous host (default "localhost").
+
+    Returns
+    -------
+    str
+        The launch-script text.
+    """
+    # Driver (LAMMPS) command: resolve the ini templates the same way
+    # executor.run does (nested .format), then add the MDI DRIVER flag.
+    driver = config["code"]
+    while True:
+        resolved = driver.format(**config, **ce)
+        if resolved == driver:
+            break
+        driver = resolved
+    if config.get("cmd-args", "") != "":
+        driver += " " + config["cmd-args"]
+    driver += (
+        f' -mdi "-role DRIVER -name LAMMPS -method TCP '
+        f'-port {port} -hostname {hostname}" -in input.dat'
+    )
+
+    return (
+        "#!/bin/bash\n"
+        "set -e\n"
+        f"{shlex.join(engine_argv)} &\n"
+        "ENGINE_PID=$!\n"
+        f"{driver}\n"
+        "wait $ENGINE_PID\n"
+    )
 
 
 # Temporarily used here to stop pymbar's annoying warning.
@@ -628,6 +702,11 @@ class LAMMPS(seamm.Node):
 
     def ff_form(self):
         """Return the form of the forcefield."""
+        # A QM-MD flowchart selects a model chemistry (Model Chemistry step)
+        # and has no Forcefield step, so check this *before* "_forcefield",
+        # which would not exist. See campaigns/2026-06-22/NOTES_C.rst (D1).
+        if self.variable_exists("_model_chemistry"):
+            return "MDI/QM"
         ff = self.get_variable("_forcefield")
         if ff == "OpenKIM":
             ff_form = "OpenKIM"
@@ -640,6 +719,56 @@ class LAMMPS(seamm.Node):
                 ff_form = "unknown"
         return ff_form
 
+    def _mdi_engine_launch(self, configuration):
+        """Resolve the "_model_chemistry" selection into an MDI engine launch.
+
+        Reads the "_model_chemistry" workspace variable published by the Model
+        Chemistry step (Phase B), validates that the selection can be driven via
+        MDI, resolves the owning program step, and asks it for the engine launch
+        argv (Phase A's get_mdi_engine_command). LAMMPS is the driver and owns
+        the rendezvous, so the TCP port is chosen here and passed to the engine;
+        the driver side must use the same port and hostname.
+
+        Parameters
+        ----------
+        configuration : molsystem._Configuration
+            The current configuration, for periodicity and the charge /
+            multiplicity (the SEAMM convention -- never from the model
+            chemistry step).
+
+        Returns
+        -------
+        (list of str, int)
+            The engine launch argv and the TCP port both sides must use.
+        """
+        mc = self.get_variable("_model_chemistry")
+        options = mc["options"]
+
+        periodic = configuration.periodicity != 0
+        if not options.get("mdi_capable", False):
+            raise ValueError(
+                f"The model chemistry '{mc['model_chemistry']}' cannot be driven "
+                "via MDI; choose an MDI-capable model chemistry."
+            )
+        if periodic and not options.get("periodic_mdi", False):
+            raise ValueError(
+                f"The model chemistry '{mc['model_chemistry']}' is not validated "
+                "for periodic systems via MDI."
+            )
+
+        port = _free_tcp_port()
+        step = self.flowchart.plugin_manager.get(mc["step"])
+        engine_argv = step.get_mdi_engine_command(
+            self.flowchart.executor,
+            self.global_options,
+            method=mc["method"],
+            port=port,
+            hostname="localhost",
+            charge=configuration.charge,
+            multiplicity=configuration.spin_multiplicity,
+        )
+        return engine_argv, port
+
     def run(self):
         """Run a LAMMPS simulation"""
 
@@ -647,14 +776,18 @@ class LAMMPS(seamm.Node):
 
         # Set the model
         try:
-            ff = self.get_variable("_forcefield")
-            if ff == "OpenKIM":
-                self.model = "OpenKIM/" + self.get_variable("_OpenKIM_Potential")
-            elif ff == "PyTorch":
-                path = Path(self.get_variable("_pytorch_model"))
-                self.model = "PyTorch/" + path.stem
+            if self.variable_exists("_model_chemistry"):
+                mc = self.get_variable("_model_chemistry")
+                self.model = "MDI/QM/" + mc["model_chemistry"]
             else:
-                self.model = ff.current_forcefield
+                ff = self.get_variable("_forcefield")
+                if ff == "OpenKIM":
+                    self.model = "OpenKIM/" + self.get_variable("_OpenKIM_Potential")
+                elif ff == "PyTorch":
+                    path = Path(self.get_variable("_pytorch_model"))
+                    self.model = "PyTorch/" + path.stem
+                else:
+                    self.model = ff.current_forcefield
         except Exception:
             self.model = None
 
@@ -784,15 +917,19 @@ class LAMMPS(seamm.Node):
         files = {}
 
         control = []
-        ff = self.get_variable("_forcefield")
-        if ff == "OpenKIM":
-            potential = self.get_variable("_OpenKIM_Potential")
-            control.append(["forcefield", "OpenKIM " + potential])
-        elif ff == "PyTorch":
-            model = self.get_variable("_pytorch_model")
-            control.append(["forcefield", "PyTorch " + model])
+        if self.variable_exists("_model_chemistry"):
+            mc = self.get_variable("_model_chemistry")
+            control.append(["model_chemistry", mc["model_chemistry"]])
         else:
-            control.append(["forcefield", ff.current_forcefield])
+            ff = self.get_variable("_forcefield")
+            if ff == "OpenKIM":
+                potential = self.get_variable("_OpenKIM_Potential")
+                control.append(["forcefield", "OpenKIM " + potential])
+            elif ff == "PyTorch":
+                model = self.get_variable("_pytorch_model")
+                control.append(["forcefield", "PyTorch " + model])
+            else:
+                control.append(["forcefield", ff.current_forcefield])
         while node is not None:
             P = node.parameters.current_values_to_dict(
                 context=seamm.flowchart_variables._data
@@ -1123,7 +1260,17 @@ class LAMMPS(seamm.Node):
             # Setup the command lines
             cmd = []
 
-            if "run_lammps" in files:
+            if ff_form == "MDI/QM":
+                # QM-MD over MDI: launch the QM engine (the listener, in its own
+                # conda environment) and the LAMMPS driver together, rendezvousing
+                # over TCP. See campaigns/2026-06-22/NOTES_C.rst.
+                _, configuration = self.get_system_configuration()
+                engine_argv, port = self._mdi_engine_launch(configuration)
+                files["mdi_launch.sh"] = _mdi_launch_script(
+                    engine_argv, port, config, ce
+                )
+                cmd = ["bash", "mdi_launch.sh"]
+            elif "run_lammps" in files:
                 cmd = ["{python}", "run_lammps"]
                 if (
                     "NGPUS" not in ce
@@ -2933,24 +3080,23 @@ class LAMMPS(seamm.Node):
             The name for this section in the file.
 
         values : {str: int, float, or str}
-            The dictionary of the constants for this angle term.
+            The dictionary of the constants for this angle term. It looks like
+            this::
+
+                {
+                    'reference': '5',
+                    'Eqn': 'K/8*(1-cos(n*Theta)) + A/(2*Rb*sin(Theta/2))**12',
+                    'K': 278.4416826003824,
+                    'n': 4,
+                    'Rb': 1.606,
+                    'A': 11.950286806883364,
+                    'zero-shift': 0.001
+                }
 
         Returns
         -------
         [str]
             A list of lines of the tabulated angle file.
-
-        values looks like this::
-
-            {
-                'reference': '5',
-                'Eqn': 'K/8*(1-cos(n*Theta)) + A/(2*Rb*sin(Theta/2))**12',
-                'K': 278.4416826003824,
-                'n': 4,
-                'Rb': 1.606,
-                'A': 11.950286806883364,
-                'zero-shift': 0.001
-            }
         """
         lines = []
 

--- a/lammps_step/lammps.py
+++ b/lammps_step/lammps.py
@@ -681,7 +681,7 @@ class LAMMPS(seamm.Node):
         ff_form = self.ff_form()
 
         # Only worry about GPU's when using PyTorch, for the moment
-        if ff_form == "PyTorch":
+        if ff_form == "PyTorch" and platform.system() != "Darwin":
             maxload = float(o["gpu_load"]) / 100
             t0 = time.time()
             t = o["gpu_wait_time"]
@@ -730,7 +730,7 @@ class LAMMPS(seamm.Node):
                         f"limit of {int(global_options['ncores'])} cores."
                     )
                 np = min(np, int(global_options["ncores"]))
-            if ff_form == "PyTorch":
+            if ff_form == "PyTorch" and platform.system() != "Darwin":
                 if ngpus < 1:
                     printer.important(
                         "    Using PyTorch forcefield, but no GPUs! Must exit."

--- a/lammps_step/lammps.py
+++ b/lammps_step/lammps.py
@@ -747,12 +747,12 @@ class LAMMPS(seamm.Node):
         periodic = configuration.periodicity != 0
         if not options.get("mdi_capable", False):
             raise ValueError(
-                f"The model chemistry '{mc['model_chemistry']}' cannot be driven "
+                f"The model chemistry '{mc['level']}' cannot be driven "
                 "via MDI; choose an MDI-capable model chemistry."
             )
         if periodic and not options.get("periodic_mdi", False):
             raise ValueError(
-                f"The model chemistry '{mc['model_chemistry']}' is not validated "
+                f"The model chemistry '{mc['level']}' is not validated "
                 "for periodic systems via MDI."
             )
 
@@ -769,6 +769,33 @@ class LAMMPS(seamm.Node):
         )
         return engine_argv, port
 
+    def model_chemistry(self, task):
+        """Compose the full ``driver:task|level`` provenance label for a task.
+
+        ``task`` is the LAMMPS operation -- ``"SP"``, ``"OPT"``, ``"MD"``. For a
+        QM-MD-over-MDI run the level (owner/type/method/...) comes from the
+        ``_model_chemistry`` variable, giving e.g.
+        ``"LAMMPS:MD|MOPAC:SQM@PM6-ORG"`` (or, classical, the owner collapses to
+        ``"LAMMPS:MD|VFF@OPLS-AA"``). For classical / MLFF / OpenKIM runs the
+        level is not yet classified into ``type@method``, so the legacy bare
+        label (``self.model``) is returned unchanged. See
+        ``model_chemistry_naming.rst``.
+        """
+        if self.variable_exists("_model_chemistry"):
+            from model_chemistry_step.grammar import compose_model_chemistry
+
+            mc = self.get_variable("_model_chemistry")
+            return compose_model_chemistry(
+                driver="LAMMPS",
+                task=task,
+                owner=mc["owner"],
+                type=mc["type"],
+                method=mc["method"],
+                basis=mc["basis"],
+                cutoff=mc["cutoff"],
+            )
+        return self.model
+
     def run(self):
         """Run a LAMMPS simulation"""
 
@@ -777,8 +804,11 @@ class LAMMPS(seamm.Node):
         # Set the model
         try:
             if self.variable_exists("_model_chemistry"):
+                # Task-agnostic provenance base; the per-operation substeps
+                # compose the full "LAMMPS:<task>|<level>" label via
+                # model_chemistry(task). See model_chemistry_naming.rst.
                 mc = self.get_variable("_model_chemistry")
-                self.model = "MDI/QM/" + mc["model_chemistry"]
+                self.model = mc["level"]
             else:
                 ff = self.get_variable("_forcefield")
                 if ff == "OpenKIM":
@@ -919,7 +949,7 @@ class LAMMPS(seamm.Node):
         control = []
         if self.variable_exists("_model_chemistry"):
             mc = self.get_variable("_model_chemistry")
-            control.append(["model_chemistry", mc["model_chemistry"]])
+            control.append(["model_chemistry", mc["level"]])
         else:
             ff = self.get_variable("_forcefield")
             if ff == "OpenKIM":
@@ -1117,6 +1147,13 @@ class LAMMPS(seamm.Node):
             else:
                 result["stderr"] = ""
         else:
+            # For QM-MD over MDI the QM engine does essentially all the work and
+            # is the bottleneck; LAMMPS is just the driver, so run it on a single
+            # core (the OMP/MKL thread caps below keep the engine single-threaded
+            # too). See campaigns/2026-06-22/NOTES_C.rst.
+            if self.ff_form() == "MDI/QM":
+                np = 1
+
             # Set up the computational limits and get the computational enviroment
             cl = {"NTASKS": np}
             ce = seamm_exec.computational_environment(cl)
@@ -1243,8 +1280,16 @@ class LAMMPS(seamm.Node):
                 env["OMP_PLACES"] = "threads"
                 env["OMP_NUM_THREADS"] = "1"  # usually best for GPU-dominant runs
 
-            # The forcefield file for PyTorch/MDI runs
-            if self.model.startswith("PyTorch/"):
+            # Keep the QM engine (MOPAC) and the LAMMPS driver single-threaded:
+            # the engine is a small serial SQM calc and oversubscribing cores
+            # only hurts. Applies to the whole launch script, so both inherit it.
+            if ff_form == "MDI/QM":
+                env["OMP_NUM_THREADS"] = "1"
+                env["MKL_NUM_THREADS"] = "1"
+
+            # The forcefield file for PyTorch/MDI runs (keyed off the forcefield
+            # form, not the model label, which is now a grammar string).
+            if ff_form == "PyTorch":
                 env["SEAMM_FF"] = self.get_variable("_pytorch_model")
             else:
                 env["SEAMM_FF"] = "Unknown"

--- a/lammps_step/minimization.py
+++ b/lammps_step/minimization.py
@@ -31,6 +31,9 @@ minimization_style = {
 
 
 class Minimization(lammps_step.Energy):
+    # Geometry optimization: the model-chemistry task for the provenance label.
+    task = "OPT"
+
     def __init__(self, flowchart=None, title="Minimization", extension=None):
         """Initialize the node"""
 
@@ -497,10 +500,11 @@ class Minimization(lammps_step.Energy):
 
         timestep = lammps_step.to_lammps_units(P["timestep"], quantity="time")
 
-        thermo_properties = (
-            "fmax fnorm press etotal ke pe ebond eangle edihed eimp evdwl etail ecoul "
-            "elong"
-        )
+        thermo_properties = "fmax fnorm press etotal ke pe"
+        # PyTorch (MACE) and MDI/QM get their energy from an external engine, so
+        # LAMMPS computes no bonded/pair terms -- those columns would be all zero.
+        if self.parent.ff_form() not in ("PyTorch", "MDI/QM"):
+            thermo_properties += " ebond eangle edihed eimp evdwl etail ecoul elong"
         if self.parent.have_dreiding_hbonds:
             thermo_properties += " v_N_hbond v_E_hbond"
 

--- a/lammps_step/npt.py
+++ b/lammps_step/npt.py
@@ -193,10 +193,10 @@ class NPT(lammps_step.NVT):
         # Work out the pressure/stress part of the command
         ptext = self.get_pressure_text(P)
 
-        thermo_properties = (
-            "time temp press etotal ke pe ebond "
-            "eangle edihed eimp evdwl etail ecoul elong"
-        )
+        form = self.parent.ff_form()
+        thermo_properties = "time temp press etotal ke pe"
+        if form != "PyTorch":
+            thermo_properties += " ebond eangle edihed eimp evdwl etail ecoul elong"
 
         properties = (
             "v_time v_temp v_press v_vol v_density "

--- a/lammps_step/npt.py
+++ b/lammps_step/npt.py
@@ -195,7 +195,9 @@ class NPT(lammps_step.NVT):
 
         form = self.parent.ff_form()
         thermo_properties = "time temp press etotal ke pe"
-        if form != "PyTorch":
+        # PyTorch (MACE) and MDI/QM get their energy from an external engine, so
+        # LAMMPS computes no bonded/pair terms -- those columns would be all zero.
+        if form not in ("PyTorch", "MDI/QM"):
             thermo_properties += " ebond eangle edihed eimp evdwl etail ecoul elong"
 
         properties = (

--- a/lammps_step/nve.py
+++ b/lammps_step/nve.py
@@ -577,10 +577,10 @@ class NVE(lammps_step.Energy):
         # time = lammps_step.to_lammps_units(P['time'], quantity='time')
         # nsteps = round(time / timestep)
 
-        thermo_properties = (
-            "time temp press etotal ke pe ebond "
-            "eangle edihed eimp evdwl etail ecoul elong"
-        )
+        form = self.parent.ff_form()
+        thermo_properties = "time temp press etotal ke pe"
+        if form != "PyTorch":
+            thermo_properties += " ebond eangle edihed eimp evdwl etail ecoul elong"
         properties = "v_time v_temp v_press v_etotal v_ke v_pe v_emol v_epair"
         title2 = "tstep t T P Etot Eke Epe Emol Epair"
         if configuration.periodicity == 3:

--- a/lammps_step/nve.py
+++ b/lammps_step/nve.py
@@ -26,6 +26,9 @@ printer = printing.getPrinter("lammps")
 
 
 class NVE(lammps_step.Energy):
+    # Molecular dynamics: the model-chemistry task for the provenance label.
+    task = "MD"
+
     def __init__(
         self,
         flowchart=None,
@@ -579,7 +582,9 @@ class NVE(lammps_step.Energy):
 
         form = self.parent.ff_form()
         thermo_properties = "time temp press etotal ke pe"
-        if form != "PyTorch":
+        # PyTorch (MACE) and MDI/QM get their energy from an external engine, so
+        # LAMMPS computes no bonded/pair terms -- those columns would be all zero.
+        if form not in ("PyTorch", "MDI/QM"):
             thermo_properties += " ebond eangle edihed eimp evdwl etail ecoul elong"
         properties = "v_time v_temp v_press v_etotal v_ke v_pe v_emol v_epair"
         title2 = "tstep t T P Etot Eke Epe Emol Epair"

--- a/lammps_step/nve_parameters.py
+++ b/lammps_step/nve_parameters.py
@@ -59,7 +59,7 @@ class NVE_Parameters(lammps_step.EnergyParameters):
                 "without hydrogen, helium, lithium or other light "
                 "elements, 2-4 fs steps are reasonable. The "
                 "timestep needs to be less than 1/10 the highest "
-                "frequency. 10^14 Hz is a period if 10 fs, and "
+                "frequency. 10^14 Hz is a period of 10 fs, and "
                 "corresponds to a frequency of 3,300 wavenumbers or "
                 "a wavelength of 3 micrometers.\n"
                 "You can enter a value or use the choices, which pick a "
@@ -94,6 +94,15 @@ class NVE_Parameters(lammps_step.EnergyParameters):
                 "\nYou can ask for no sampling, give a specific interval, "
                 "or allow the system the choose for you."
             ),
+        },
+        "constrain X-H bonds": {
+            "default": "no",
+            "kind": "boolean",
+            "default_units": None,
+            "enumeration": ("yes", "no"),
+            "format_string": "",
+            "description": "Constrain (shake) X-H bonds:",
+            "help_text": "Whether to fix the length of X-H bonds using SHAKE/RATTLE",
         },
     }
     trajectories = {

--- a/lammps_step/nvt.py
+++ b/lammps_step/nvt.py
@@ -214,7 +214,9 @@ class NVT(lammps_step.NVE):
 
         form = self.parent.ff_form()
         thermo_properties = "time temp press etotal ke pe"
-        if form != "PyTorch":
+        # PyTorch (MACE) and MDI/QM get their energy from an external engine, so
+        # LAMMPS computes no bonded/pair terms -- those columns would be all zero.
+        if form not in ("PyTorch", "MDI/QM"):
             thermo_properties += " ebond eangle edihed eimp evdwl etail ecoul elong"
         properties = "v_time v_temp v_press v_etotal v_ke v_pe v_epair"
         title2 = "tstep t T P Etot Eke Epe Epair"

--- a/lammps_step/nvt.py
+++ b/lammps_step/nvt.py
@@ -212,10 +212,10 @@ class NVT(lammps_step.NVE):
         T1 = lammps_step.to_lammps_units(P["T1"], quantity="temperature")
         Tdamp = lammps_step.to_lammps_units(P["Tdamp"], quantity="time")
 
-        thermo_properties = (
-            "time temp press etotal ke pe ebond "
-            "eangle edihed eimp evdwl etail ecoul elong"
-        )
+        form = self.parent.ff_form()
+        thermo_properties = "time temp press etotal ke pe"
+        if form != "PyTorch":
+            thermo_properties += " ebond eangle edihed eimp evdwl etail ecoul elong"
         properties = "v_time v_temp v_press v_etotal v_ke v_pe v_epair"
         title2 = "tstep t T P Etot Eke Epe Epair"
         if configuration.periodicity == 3:

--- a/tests/test_mdi_qm.py
+++ b/tests/test_mdi_qm.py
@@ -101,9 +101,11 @@ def _fake_self(mc=None, variables=None, step=None):
 
 
 def _mc(mdi_capable=True, periodic_mdi=False):
+    # The _model_chemistry wrapper as the Model Chemistry step now stores it:
+    # a level spec (owner/type/method/...), not a full model chemistry.
     return {
-        "model_chemistry": "MOPAC:SQM@PM6-ORG",
-        "program": "MOPAC",
+        "level": "MOPAC:SQM@PM6-ORG",
+        "owner": "MOPAC",
         "type": "SQM",
         "method": "PM6-ORG",
         "basis": None,
@@ -204,6 +206,26 @@ def test_mdi_engine_launch_allows_periodic_when_validated():
     engine_argv, port = LAMMPS._mdi_engine_launch(me, configuration)
     assert len(step.calls) == 1
     assert engine_argv[-2:] == ["--port", str(port)]
+
+
+# ---------------------------------------------------------------------------
+# model_chemistry -- the full driver:task|level provenance label
+# ---------------------------------------------------------------------------
+def test_model_chemistry_label_composes_full_string():
+    me = _fake_self(mc=_mc())
+    # MDI/QM: LAMMPS drives, MOPAC owns the PES -> owner kept on the level side.
+    assert LAMMPS.model_chemistry(me, "MD") == "LAMMPS:MD|MOPAC:SQM@PM6-ORG"
+    assert LAMMPS.model_chemistry(me, "OPT") == "LAMMPS:OPT|MOPAC:SQM@PM6-ORG"
+
+
+def test_model_chemistry_label_classical_falls_back():
+    """With no _model_chemistry (classical/MLFF/OpenKIM) the legacy bare label
+    is returned unchanged -- no spurious grammar string."""
+    me = types.SimpleNamespace(
+        variable_exists=lambda name: False,
+        model="OPLS-AA",
+    )
+    assert LAMMPS.model_chemistry(me, "MD") == "OPLS-AA"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mdi_qm.py
+++ b/tests/test_mdi_qm.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for the QM-MD-over-MDI (Phase C) path in ``lammps_step``.
+
+These exercise the driver-side pieces that read the ``_model_chemistry``
+variable published by the Model Chemistry step and launch the QM MDI engine:
+
+* ``_free_tcp_port`` -- the rendezvous port helper.
+* ``LAMMPS.ff_form`` -- detecting the QM path before touching ``_forcefield``.
+* ``LAMMPS._mdi_engine_launch`` -- MDI-capability gating and resolving the
+  owning program step's engine command.
+* ``_mdi_launch_script`` -- composing the engine + driver launch script.
+
+The step methods are called as *unbound* methods on a lightweight fake ``self``
+so no real flowchart/executor is needed. See
+docs/.../campaigns/2026-06-22/NOTES_C.rst.
+"""
+
+import shlex
+import socket
+import types
+
+import pytest
+
+from lammps_step.lammps import LAMMPS, _free_tcp_port, _mdi_launch_script
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+class _FakeStep:
+    """Stand-in for a program step exposing get_mdi_engine_command.
+
+    Records the keyword arguments it was called with and echoes the port back
+    in the argv, so a test can confirm the port was threaded through.
+    """
+
+    def __init__(self, argv):
+        self._argv = list(argv)
+        self.calls = []
+
+    def get_mdi_engine_command(
+        self,
+        executor,
+        seamm_options,
+        *,
+        method,
+        port,
+        hostname="localhost",
+        charge=0,
+        multiplicity=1,
+    ):
+        self.calls.append(
+            {
+                "executor": executor,
+                "seamm_options": seamm_options,
+                "method": method,
+                "port": port,
+                "hostname": hostname,
+                "charge": charge,
+                "multiplicity": multiplicity,
+            }
+        )
+        return [*self._argv, "--port", str(port)]
+
+
+class _FakePluginManager:
+    def __init__(self, mapping):
+        self._mapping = mapping
+
+    def get(self, name):
+        return self._mapping[name]
+
+
+def _fake_self(mc=None, variables=None, step=None):
+    """Build a fake LAMMPS node exposing only what the methods under test use."""
+    variables = dict(variables or {})
+    if mc is not None:
+        variables["_model_chemistry"] = mc
+
+    def get_variable(name):
+        return variables[name]
+
+    def variable_exists(name):
+        return name in variables
+
+    plugin_manager = None
+    if step is not None and mc is not None:
+        plugin_manager = _FakePluginManager({mc["step"]: step})
+
+    return types.SimpleNamespace(
+        get_variable=get_variable,
+        variable_exists=variable_exists,
+        global_options={"root": "~/SEAMM"},
+        flowchart=types.SimpleNamespace(
+            plugin_manager=plugin_manager,
+            executor="FAKE-EXECUTOR",
+        ),
+    )
+
+
+def _mc(mdi_capable=True, periodic_mdi=False):
+    return {
+        "model_chemistry": "MOPAC:SQM@PM6-ORG",
+        "program": "MOPAC",
+        "type": "SQM",
+        "method": "PM6-ORG",
+        "basis": None,
+        "cutoff": None,
+        "step": "mopac-step",
+        "options": {
+            "mdi_capable": mdi_capable,
+            "periodic_mdi": periodic_mdi,
+            "mdi_method_arg": "PM6-ORG",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# _free_tcp_port
+# ---------------------------------------------------------------------------
+def test_free_tcp_port_is_a_usable_port():
+    port = _free_tcp_port()
+    assert isinstance(port, int)
+    assert 1 <= port <= 65535
+    # It should be free right now -- we can bind it ourselves.
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(("localhost", port))
+    finally:
+        s.close()
+
+
+# ---------------------------------------------------------------------------
+# ff_form
+# ---------------------------------------------------------------------------
+def test_ff_form_detects_model_chemistry():
+    """_model_chemistry present -> "MDI/QM", without reading _forcefield."""
+    me = _fake_self(mc=_mc())
+    assert LAMMPS.ff_form(me) == "MDI/QM"
+
+
+def test_ff_form_does_not_touch_forcefield_on_qm_path():
+    """The QM branch must come first: _forcefield does not exist in a QM-MD
+    flowchart, so reading it would raise."""
+    me = _fake_self(mc=_mc())  # only "_model_chemistry" is defined
+    # If ff_form read "_forcefield" it would KeyError; it must not.
+    assert LAMMPS.ff_form(me) == "MDI/QM"
+
+
+def test_ff_form_classical_path_unchanged():
+    me = _fake_self(variables={"_forcefield": "OpenKIM"})
+    assert LAMMPS.ff_form(me) == "OpenKIM"
+
+
+# ---------------------------------------------------------------------------
+# _mdi_engine_launch
+# ---------------------------------------------------------------------------
+def test_mdi_engine_launch_happy_path():
+    step = _FakeStep(["conda", "run", "-n", "seamm-mopac", "python", "mopac_mdi.py"])
+    me = _fake_self(mc=_mc(mdi_capable=True), step=step)
+    configuration = types.SimpleNamespace(periodicity=0, charge=-1, spin_multiplicity=2)
+
+    engine_argv, port = LAMMPS._mdi_engine_launch(me, configuration)
+
+    assert isinstance(port, int) and 1 <= port <= 65535
+    # The owning step was resolved by its Stevedore handle and called correctly.
+    assert len(step.calls) == 1
+    call = step.calls[0]
+    assert call["method"] == "PM6-ORG"
+    assert call["port"] == port
+    assert call["hostname"] == "localhost"
+    assert call["charge"] == -1  # from the configuration (D6)
+    assert call["multiplicity"] == 2  # from the configuration (D6)
+    assert call["executor"] == "FAKE-EXECUTOR"
+    assert call["seamm_options"] == {"root": "~/SEAMM"}
+    # The returned argv is exactly what the step produced.
+    assert engine_argv[-2:] == ["--port", str(port)]
+
+
+def test_mdi_engine_launch_rejects_non_mdi_capable():
+    step = _FakeStep(["python", "engine.py"])
+    me = _fake_self(mc=_mc(mdi_capable=False), step=step)
+    configuration = types.SimpleNamespace(periodicity=0, charge=0, spin_multiplicity=1)
+    with pytest.raises(ValueError, match="cannot be driven"):
+        LAMMPS._mdi_engine_launch(me, configuration)
+    assert step.calls == []  # never reached the engine
+
+
+def test_mdi_engine_launch_rejects_periodic_without_periodic_mdi():
+    step = _FakeStep(["python", "engine.py"])
+    me = _fake_self(mc=_mc(mdi_capable=True, periodic_mdi=False), step=step)
+    configuration = types.SimpleNamespace(periodicity=3, charge=0, spin_multiplicity=1)
+    with pytest.raises(ValueError, match="periodic"):
+        LAMMPS._mdi_engine_launch(me, configuration)
+    assert step.calls == []
+
+
+def test_mdi_engine_launch_allows_periodic_when_validated():
+    step = _FakeStep(["python", "engine.py"])
+    me = _fake_self(mc=_mc(mdi_capable=True, periodic_mdi=True), step=step)
+    configuration = types.SimpleNamespace(periodicity=3, charge=0, spin_multiplicity=1)
+    engine_argv, port = LAMMPS._mdi_engine_launch(me, configuration)
+    assert len(step.calls) == 1
+    assert engine_argv[-2:] == ["--port", str(port)]
+
+
+# ---------------------------------------------------------------------------
+# _mdi_launch_script
+# ---------------------------------------------------------------------------
+def test_launch_script_shape_and_port_threading():
+    port = 54321
+    engine_argv = [
+        "conda",
+        "run",
+        "--live-stream",
+        "-n",
+        "seamm-mopac",
+        "python",
+        "/abs/mopac_mdi.py",
+        "-mdi",
+        "-role ENGINE -name MOPAC -method TCP -port 54321 -hostname localhost",
+        "--method",
+        "PM6-ORG",
+    ]
+    config = {"code": "mpirun -np {NTASKS} lmp", "installation": "conda"}
+    ce = {"NTASKS": 4}
+
+    script = _mdi_launch_script(engine_argv, port, config, ce)
+    lines = script.splitlines()
+
+    # Shape: shebang, set -e, engine &, capture pid, driver, wait.
+    assert lines[0] == "#!/bin/bash"
+    assert lines[1] == "set -e"
+    assert lines[2].endswith(" &")  # engine backgrounded first
+    assert "mopac_mdi.py" in lines[2]
+    assert lines[3] == "ENGINE_PID=$!"
+    assert lines[-1] == "wait $ENGINE_PID"
+
+    # The engine line is exactly shlex.join(argv) + " &" -- so the -mdi value
+    # (which contains spaces) is quoted as one token.
+    assert lines[2] == shlex.join(engine_argv) + " &"
+    assert (
+        "'-role ENGINE -name MOPAC -method TCP -port 54321 -hostname localhost'"
+        in lines[2]
+    )
+
+    # The driver line: ini template resolved, MDI DRIVER flag with the SAME
+    # port/hostname, and the input file appended.
+    driver_line = lines[4]
+    assert driver_line.startswith("mpirun -np 4 lmp")  # {NTASKS} -> 4
+    assert (
+        '-mdi "-role DRIVER -name LAMMPS -method TCP -port 54321 -hostname localhost"'
+        in driver_line
+    )
+    assert driver_line.endswith("-in input.dat")
+
+
+def test_launch_script_appends_cmd_args():
+    script = _mdi_launch_script(
+        ["engine"], 7000, {"code": "lmp", "cmd-args": "-sf omp"}, {"NTASKS": 1}
+    )
+    assert "lmp -sf omp -mdi " in script
+
+
+def test_launch_script_custom_hostname():
+    script = _mdi_launch_script(
+        ["engine"], 7000, {"code": "lmp"}, {"NTASKS": 1}, hostname="node07"
+    )
+    assert "-hostname node07" in script


### PR DESCRIPTION
Phase C MDI driver path consuming _model_chemistry, plus single-core/thread, clean thermo, and LAMMPS:MD|MOPAC:SQM@PM6-ORG provenance labels.