### PR TITLE
QM-MD over MDI: engine threading, comm cutoff, pre-run reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,12 @@ install: uninstall ## install the package to the active Python's site-packages
 
 uninstall: clean ## uninstall the package
 	pip uninstall --yes $(MODULE)
+
+.PHONY: update
+update: ## post-release: sync main and dev, reinstall, run checks, push dev
+	git checkout main
+	git pull
+	git checkout dev
+	git merge --ff-only main
+	$(MAKE) lint install test
+	git push

--- a/docs/developer_guide/campaigns/2026-06-22/NOTES_C.rst
+++ b/docs/developer_guide/campaigns/2026-06-22/NOTES_C.rst
@@ -6,14 +6,19 @@ Phase C -- LAMMPS driver: read ``_model_chemistry``, launch the MDI engine
 
 :Author: Paul Saxe (with Claude)
 :Date: 2026-06-24
-:Status: MDI launch path verified end-to-end (2026-06-24). ``lammps.py`` +
-         ``initialization.py`` + unit tests (14 pass). A MOPAC PM6-ORG
-         minimization of a 45-atom C/O/H system ran via MDI: engine launched in
-         seamm-mopac, connected over TCP, drove LAMMPS, exited cleanly (energy
-         -266.7 -> -309.5 kcal/mol). Open: the CG min stopped at
-         "linesearch alpha is zero" (not converged) -- investigate QM
-         energy/force consistency, separate from the launch path. NOTE: reusing
-         the lammps.ini ``code`` key requires it to be a plain LAMMPS launcher
+:Status: Verified end-to-end (2026-06-25). MOPAC PM6-ORG drives LAMMPS via MDI
+         across minimization, NVT, and NPT (e.g. NPT on 20 cyclohexane
+         molecules, density ~0.89 g/mL): engine launched in seamm-mopac,
+         connected over TCP, exited cleanly. Results carry the proper
+         model-chemistry label ``LAMMPS:MD|MOPAC:SQM@PM6-ORG`` (``LAMMPS:OPT|...``
+         for minimization). ``lammps.py`` + ``initialization.py`` + unit tests
+         pass; single-core/thread and clean thermo refinements applied. Shipped
+         on ``dev``/``main``.
+
+         Notes carried forward: an early CG minimization stopped at "linesearch
+         alpha is zero" (not converged) -- a QM energy/force-consistency question
+         separate from the launch path, worth revisiting. And: reusing the
+         lammps.ini ``code`` key requires it to be a plain LAMMPS launcher
          (``mpirun -n {NTASKS} lmp``), NOT a MACE-style MDI/MPMD line -- that is
          what ``gpu-code`` is for.
 :Campaign: LAMMPS + MOPAC/xTB QM-MD via MDI

--- a/lammps_step/initialization.py
+++ b/lammps_step/initialization.py
@@ -877,6 +877,14 @@ class Initialization(seamm.Node):
                 " or 3-D periodicity at the moment!"
             )
         lines.append("")
+        # With no pair_style, LAMMPS has no cutoff to size its communication
+        # shell / neighbor bins from, so it warns ("Communication cutoff is
+        # 0.0 ... Atoms may get lost") and disables atom sorting. Give it a
+        # small communication cutoff so atom migration and ghost exchange work
+        # (essential for periodic and multi-processor runs); this is not a
+        # model interaction range -- the QM engine still gets the whole system.
+        lines.append("comm_modify         cutoff 2.0")
+        lines.append("")
         lines.append("fix                 prop all property/atom mol")
         lines.append("read_data           structure.dat fix prop NULL Molecules")
         lines.append("")

--- a/lammps_step/lammps.py
+++ b/lammps_step/lammps.py
@@ -766,6 +766,7 @@ class LAMMPS(seamm.Node):
             hostname="localhost",
             charge=configuration.charge,
             multiplicity=configuration.spin_multiplicity,
+            n_atoms=configuration.n_atoms,
         )
         return engine_argv, port
 

--- a/lammps_step/lammps.py
+++ b/lammps_step/lammps.py
@@ -1341,9 +1341,31 @@ class LAMMPS(seamm.Node):
                         cmd.extend(config["cmd-args"].split())
                 cmd.extend(["-in", "input.dat"])
 
+            # Say what is producing the forces -- a model chemistry (QM via
+            # MDI) or a forcefield -- before reporting the parallelism.
+            if ff_form == "MDI/QM":
+                printer.important(
+                    __(
+                        f"Using the model chemistry '{self.model}', with the "
+                        "energy and forces evaluated by a QM engine via MDI.",
+                        indent=4 * " ",
+                    )
+                )
+            elif self.model:
+                printer.important(f"    Using the forcefield '{self.model}'.")
+
             if "NGPUS" in ce:
                 printer.important(
                     f"    LAMMPS running with {np} processes and {ce['NGPUS']} gpus."
+                )
+            elif ff_form == "MDI/QM":
+                printer.important(
+                    __(
+                        "LAMMPS is running on a single core: it only drives the "
+                        "dynamics and does very little work, while the QM engine "
+                        "(reached over MDI) computes the energy and forces.",
+                        indent=4 * " ",
+                    )
                 )
             else:
                 printer.important(f"    LAMMPS using MPI with {np} processes.")

--- a/tests/test_mdi_qm.py
+++ b/tests/test_mdi_qm.py
@@ -50,6 +50,7 @@ class _FakeStep:
         hostname="localhost",
         charge=0,
         multiplicity=1,
+        n_atoms=None,
     ):
         self.calls.append(
             {
@@ -60,6 +61,7 @@ class _FakeStep:
                 "hostname": hostname,
                 "charge": charge,
                 "multiplicity": multiplicity,
+                "n_atoms": n_atoms,
             }
         )
         return [*self._argv, "--port", str(port)]
@@ -162,7 +164,9 @@ def test_ff_form_classical_path_unchanged():
 def test_mdi_engine_launch_happy_path():
     step = _FakeStep(["conda", "run", "-n", "seamm-mopac", "python", "mopac_mdi.py"])
     me = _fake_self(mc=_mc(mdi_capable=True), step=step)
-    configuration = types.SimpleNamespace(periodicity=0, charge=-1, spin_multiplicity=2)
+    configuration = types.SimpleNamespace(
+        periodicity=0, charge=-1, spin_multiplicity=2, n_atoms=45
+    )
 
     engine_argv, port = LAMMPS._mdi_engine_launch(me, configuration)
 
@@ -193,7 +197,9 @@ def test_mdi_engine_launch_rejects_non_mdi_capable():
 def test_mdi_engine_launch_rejects_periodic_without_periodic_mdi():
     step = _FakeStep(["python", "engine.py"])
     me = _fake_self(mc=_mc(mdi_capable=True, periodic_mdi=False), step=step)
-    configuration = types.SimpleNamespace(periodicity=3, charge=0, spin_multiplicity=1)
+    configuration = types.SimpleNamespace(
+        periodicity=3, charge=0, spin_multiplicity=1, n_atoms=45
+    )
     with pytest.raises(ValueError, match="periodic"):
         LAMMPS._mdi_engine_launch(me, configuration)
     assert step.calls == []
@@ -202,7 +208,9 @@ def test_mdi_engine_launch_rejects_periodic_without_periodic_mdi():
 def test_mdi_engine_launch_allows_periodic_when_validated():
     step = _FakeStep(["python", "engine.py"])
     me = _fake_self(mc=_mc(mdi_capable=True, periodic_mdi=True), step=step)
-    configuration = types.SimpleNamespace(periodicity=3, charge=0, spin_multiplicity=1)
+    configuration = types.SimpleNamespace(
+        periodicity=3, charge=0, spin_multiplicity=1, n_atoms=45
+    )
     engine_argv, port = LAMMPS._mdi_engine_launch(me, configuration)
     assert len(step.calls) == 1
     assert engine_argv[-2:] == ["--port", str(port)]


### PR DESCRIPTION
Refinements to the LAMMPS QM-MD-over-MDI path (Phase C), now verified end-to-end with both MOPAC and xTB engines.

- Pass `n_atoms` to `get_mdi_engine_command` so an engine can size its own OpenMP threads (tblite does; MOPAC ignores it). Generic — no engine-specific knowledge in LAMMPS.
- `comm_modify cutoff 2.0` on the MDI/QM deck: with no `pair_style`, LAMMPS otherwise warns 'Communication cutoff is 0.0 ... Atoms may get lost' and disables atom sorting. Fixes a real hazard for periodic/multi-proc runs.
- Report the model chemistry / forcefield before running, and note that for MDI/QM LAMMPS runs single-core (the QM engine does the work). Printed via `__()` for wrapping.
- Mark Phase C verified end-to-end in NOTES_C; add the `update` make target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)